### PR TITLE
Update README to clarify scope of this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ of the robots tool, follows the format specified by RFC3986, since this library
 will not perform full normalization of those URI parameters. Only if the URI is
 in this format, the matching will be done according to the REP specification.
 
+Also note that the library, or the included binary, do not handle implementation
+logic that a crawler might apply outside of parsing and matching, e.g. `Applebot`
+respecting the rules specified for `User-agent: Googlebot` if not explicitly
+defined, or `Googlebot-Image` falling back to use `Googlebot` in a similar manner.
+
 ## License
 
 The robots.txt parser and matcher C++ library is licensed under the terms of the

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ will not perform full normalization of those URI parameters. Only if the URI is
 in this format, the matching will be done according to the REP specification.
 
 Also note that the library, and the included binary, do not handle implementation
-logic that a crawler might apply outside of parsing and matching, example: `Googlebot-Image`
+logic that a crawler might apply outside of parsing and matching, for example: `Googlebot-Image`
 respecting the rules specified for `User-agent: Googlebot` if not explicitly
 defined in the robots.txt file being tested.
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ of the robots tool, follows the format specified by RFC3986, since this library
 will not perform full normalization of those URI parameters. Only if the URI is
 in this format, the matching will be done according to the REP specification.
 
-Also note that the library, or the included binary, do not handle implementation
-logic that a crawler might apply outside of parsing and matching, e.g. `Applebot`
+Also note that the library, and the included binary, do not handle implementation
+logic that a crawler might apply outside of parsing and matching, example: `Googlebot-Image`
 respecting the rules specified for `User-agent: Googlebot` if not explicitly
-defined, or `Googlebot-Image` falling back to use `Googlebot` in a similar manner.
+defined in the robots.txt file being tested.
 
 ## License
 


### PR DESCRIPTION
Adds a paragraph to the notes section explaining that the library doesn't handle all the implementation logic that google, or a different crawler / agent might apply, like `Googlebot-Image` falling back to use `Googlebot` or other crawlers, like `Applebot` for example using `Googlebot` if no specific User-agent is found.

Perhaps should be obvious, but I think explicitly stating this might help clear up misconceptions.