### PR TITLE
googletest changed from master to main as their

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -18,7 +18,7 @@ ExternalProject_Add(abseilcpp
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG main
     GIT_PROGRESS 1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libs/gtest-src"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/libs/gtest-build"


### PR DESCRIPTION
https://github.com/google/googletest doesn't have a "master" branch and fails when trying to compile with cmake.
This change fixes that issue.