### PR TITLE
Fix README output examples and document exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Target //:robots_main up-to-date:
   bazel-bin/robots_main
 ...
 bazel-robots$ bazel run robots_main -- ~/local/path/to/robots.txt YourBot https://example.com/url
-  user-agent 'YourBot' with url 'https://example.com/url' allowed: YES
+  user-agent 'YourBot' with url 'https://example.com/url': ALLOWED
 ```
 
 #### Building with CMake
@@ -104,8 +104,12 @@ Test project robotstxt/c-build
 Total Test time (real) =   0.02 sec
 ...
 $ robots ~/local/path/to/robots.txt YourBot https://example.com/url
-  user-agent 'YourBot' with url 'https://example.com/url' allowed: YES
+  user-agent 'YourBot' with url 'https://example.com/url': ALLOWED
 ```
+> **Note**: If the robots file is empty, the parser also prints:
+`notice: robots file is empty so all user-agents are allowed`
+
+> **Exit codes:** `0` = `ALLOWED`, `1` = `DISALLOWED`. 
 
 ## Notes
 


### PR DESCRIPTION
This PR updates the README to align with the actual output of `robots_main.cc`:

- Fixed example output (`allowed: YES` → `: ALLOWED`)
- Documented behavior when robots.txt is empty: notice: robots file is empty, so all user-agents are allowed
- Added note on exit codes (`0` = ALLOWED, `1` = DISALLOWED`), which makes it
clear how the tool can be used in shell scripts or CI pipelines.

No code changes are included — documentation only.