### PR TITLE
Adds WASM build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@emsdk//emscripten_toolchain:wasm_rules.bzl", "wasm_cc_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -59,4 +60,22 @@ cc_binary(
     deps = [
         ":robots",
     ],
+)
+
+cc_binary(
+    name = "robots_js",
+    srcs = ["robots_wasm.cc"],
+    deps = [
+	":robots",
+    ],
+   linkopts = [
+        "-l", "embind",
+	"-s", "EXPORTED_FUNCTIONS=_IsAllowed",
+	"-s", "EXPORTED_RUNTIME_METHODS=ccall,cwrap"
+    ],
+)
+
+wasm_cc_binary(
+    name = "robots_wasm",
+    cc_target = ":robots_js",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,3 +23,8 @@ bazel_dep(
     name = "rules_cc",
     version = "0.2.17",
 )
+
+bazel_dep(
+    name = "emsdk",
+    version = "5.0.4"
+)

--- a/robots_wasm.cc
+++ b/robots_wasm.cc
@@ -1,0 +1,19 @@
+#include <emscripten/bind.h>
+#include "robots.h"
+
+// Returns true if the given user agent is allowed to crawl the URL given the robots content
+// Otherwise, returns false.
+// We also need to make sure our function gets exported as IsAllowed
+bool IsAllowed(std::string user_agent, std::string url, std::string robots_content) asm("IsAllowed");
+bool IsAllowed(std::string user_agent, std::string url, std::string robots_content) {
+  googlebot::RobotsMatcher matcher;
+  std::vector<std::string> user_agents(1, user_agent);
+  return matcher.AllowedByRobots(robots_content, &user_agents, url);
+}
+
+// Create a binding so we can call the function from JavaScript
+// Example: Module.IsAllowed('googlebot', 'https://example.com/test', 'user-agent: *\ndisallow: /') // will return false
+EMSCRIPTEN_BINDINGS(my_module) {
+  emscripten::function("IsAllowed", &IsAllowed);
+}
+


### PR DESCRIPTION
It adds a build target `:robots_wasm` that uses emscripten to create a .wasm file for use with JavaScript.
It exports an `IsAllowed` function that can be used like this:

```javascript
const ROBOTS_TXT = `
  user-agent: *
  disallow: /
`;

Module.onRuntimeInitialized = function() {
  console.log(Module.IsAllowed('googlebot', 'https://example.com/something', ROBOTS_TXT)) // outputs false
};
```

This fixes #42.